### PR TITLE
ENG-1421: Speak protobuf over the wire instead of JSON

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,84 @@
+---
+name: "🐛 Bug Report"
+description: Report a bug
+title: "(short issue description)"
+labels: [bug, needs-triage]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: What is the problem? A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: |
+        What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behavior
+      description: |
+        What actually happened?
+        
+        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
+        For more complex issues provide a repo with the smallest sample that reproduces the bug.
+        
+        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
+        The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible Solution
+      description: |
+        Suggest a fix/reason for the bug
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Information/Context
+      description: |
+        Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
+    validations:
+      required: false
+
+  - type: textarea
+    id: Go-sdk-version
+    attributes:
+      label: Moonsense Go SDK Module Versions Used
+      description: |
+        Output of `go mod graph` or `go.mod` file listing the `github.com/moonsense/*` entries.
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Compiler and Version used
+      description: output of the `go version` command
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating System and version
+    validations:
+      required: true 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,64 @@
+---
+name: 🚀 Feature Request
+description: Suggest an idea for this project
+title: "(short issue description)"
+labels: [feature-request, needs-triage]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of the feature you are proposing.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Why do you need this feature? For example: "I'm always frustrated when..."
+    validations:
+        required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        Suggest how to implement the addition or change. Please include prototype/workaround/sketch/reference implementation.
+    validations:
+      required: false
+  - type: textarea
+    id: other
+    attributes:
+      label: Other Information
+      description: |
+        Any alternative solutions or features you considered, a more detailed explanation, stack traces, related issues, links for context, etc.
+    validations:
+      required: false
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I may be able to implement this feature request
+          required: false
+        - label: This feature might incur a breaking change
+          required: false
+
+  - type: textarea
+    id: Go-sdk-version
+    attributes:
+      label: Moonsense Go SDK Module Versions Used
+      description: |
+        Output of `go mod graph` or `go.mod` file listing the `github.com/moonsense/*` entries.
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version used
+      description: Output of `go version`
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question-help.yml
+++ b/.github/ISSUE_TEMPLATE/question-help.yml
@@ -1,0 +1,38 @@
+---
+name: 💬 Question/Help
+description: Get help with issues you are experiencing
+title: "(short issue description)"
+labels: [help-wanted, question]
+assignees: []
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      description: A clear and concise description of the question.
+    validations:
+      required: true
+
+  - type: textarea
+    id: Go-sdk-version
+    attributes:
+      label: Moonsense Go SDK Module Versions Used
+      description: |
+        Output of `go mod graph` or `go.mod` file listing the `github.com/moonsense/*` entries.
+    validations:
+      required: true
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version used
+      description: Output of `go version`
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating System and version
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,73 @@
 # Moonsense SDK for Go
 
-[![Apache V2 License](https://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/moonsense/go-sdk/blob/main/LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/moonsense/go-sdk/moonsense/.svg)](https://pkg.go.dev/github.com/moonsense/go-sdk/moonsense/) [![Apache V2 License](https://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/moonsense/go-sdk/blob/main/LICENSE)
 
-Go SDK for Moonsense API
+Simple Go SDK for the Moonsense Cloud API.
 
+## Installation
+
+Install the module using `go install`: 
+
+```shell
+go install github.com/moonsense/go-sdk
+```
+
+## Getting Started
+
+Start by getting an API secret key by navigating to App in Console and creating a token. You will need to save the generated secret key to a secure place.
+
+https://console.moonsense.cloud/dashboard
+
+We recommend exporting the API secret key as an environment variable:
+
+    export MOONSENSE_SECRET_TOKEN=...
+
+You can then very easily list sessions and access the granular data:
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/moonsense/go-sdk/moonsense"
+    "github.com/moonsense/go-sdk/moonsense/config"
+)
+
+func main() {
+    sdkConfig := config.SDKConfig{
+        SecretToken: "<YOUR SECRET_TOKEN>",
+    }
+
+    client := moonsense.NewClient(sdkConfig)
+
+    paginatedSession, err := client.ListSessions(config.ListSessionConfig{})
+    for {
+        if err != nil {
+            fmt.Println("Error getting session list")
+            fmt.Println(err)
+            break
+        }
+
+        for _, session := range paginatedSession.Sessions {
+            fmt.Printf("SessionId: %s, %s - %s\n", session.SessionId, session.Metadata.Platform.String(), session.CreatedAt.AsTime())
+        }
+
+        if paginatedSession.HasMoreSessions() {
+            paginatedSession, err = paginatedSession.NextPage()
+        } else {
+            break
+        }
+    }
+}
+```
+
+See [example_test.go](https://github.com/moonsense/go-sdk/blob/main/moonsense/example_test.go) for further examples.
+
+## Terms Of Service
+
+The Moonsense Go SDK is distributed under the [Moonsense Terms Of Service](https://www.moonsense.io/terms-of-service).
+
+## Support
+
+Feel free to raise an [Issue](https://github.com/moonsense/go-sdk/issues) around bugs, usage, concerns or feedback.

--- a/moonsense/api/api.go
+++ b/moonsense/api/api.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (

--- a/moonsense/api/control_plane_client.go
+++ b/moonsense/api/control_plane_client.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (

--- a/moonsense/api/data_plane_client.go
+++ b/moonsense/api/data_plane_client.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (

--- a/moonsense/config/list_session_config.go
+++ b/moonsense/config/list_session_config.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (
@@ -6,6 +20,8 @@ import (
 	commonProto "github.com/moonsense/go-sdk/moonsense/models/pb/v2/common"
 )
 
+// ListSessionConfig allows for setting the criteria to be used when requesting a
+// list of sessions.
 type ListSessionConfig struct {
 	// The number of Sessions to return per page
 	SessionsPerPage int

--- a/moonsense/config/sdk_config.go
+++ b/moonsense/config/sdk_config.go
@@ -1,5 +1,20 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
+// SDKConfig is used to configure the SDK for accessing the Moonsense Cloud.
 type SDKConfig struct {
 	// API secret token generated from the Moonsense Cloud web console
 	SecretToken string

--- a/moonsense/doc.go
+++ b/moonsense/doc.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package moonsense is the official Moonsense SDK for the Go programming language.
+//
+// # Getting started
+//
+// The best way to get started working with the SDK is to use `go install` to add the
+// SDK to your Go dependencies explicitly.
+//
+//	go install github.com/moonsense/go-sdk
+//
+// Once you have installed the SDK, you will need an API secret key. Navigate to your App in the Moonsense Console and create a token.
+// You will need to save the generated secret key to a secure place.
+//
+// https://console.moonsense.cloud/dashboard
+//
+// We recommend exporting the API secret key as an environment variable:
+//
+//	export MOONSENSE_SECRET_TOKEN=...
+//
+// You can then very easily list sessions and access the granular data:
+//
+//	package main
+//
+//	import (
+//	    "fmt"
+//
+//	    "github.com/moonsense/go-sdk/moonsense"
+//	    "github.com/moonsense/go-sdk/moonsense/config"
+//	)
+//
+//	func main() {
+//	    sdkConfig := config.SDKConfig{
+//	        SecretToken: "<YOUR SECRET_TOKEN>",
+//	    }
+//
+//	    client := moonsense.NewClient(sdkConfig)
+//
+//	    paginatedSession, err := client.ListSessions(config.ListSessionConfig{})
+//	    for {
+//	        if err != nil {
+//	            fmt.Println("Error getting session list")
+//	            fmt.Println(err)
+//	            break
+//	        }
+//
+//	        for _, session := range paginatedSession.Sessions {
+//	            fmt.Printf("SessionId: %s, %s - %s\n", session.SessionId, session.Metadata.Platform.String(), session.CreatedAt.AsTime())
+//	        }
+//
+//	        if paginatedSession.HasMoreSessions() {
+//	            paginatedSession, err = paginatedSession.NextPage()
+//	        } else {
+//	            break
+//	        }
+//	    }
+//	}
+package moonsense

--- a/moonsense/example_test.go
+++ b/moonsense/example_test.go
@@ -1,0 +1,224 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package moonsense_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/moonsense/go-sdk/moonsense"
+	"github.com/moonsense/go-sdk/moonsense/config"
+
+	commonProto "github.com/moonsense/go-sdk/moonsense/models/pb/v2/common"
+)
+
+func Example_listRegions() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	// Fetch the regions and print them
+	regions, err := client.ListRegions()
+	if err != nil {
+		fmt.Println("Error fetching region list")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(regions)
+}
+
+func Example_listSessions() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	// Configure the session list criteria.
+	//
+	// For this example, we want to retrieve 50 sessions per page that were created either with the
+	// Android or iOS SDKs with a label of "suspect_session" and were created during the month of January, 2023.
+	sessionListConfig := config.ListSessionConfig{
+		SessionsPerPage: 50,
+		Labels:          []string{"suspect_session"},
+		Platforms:       []commonProto.DevicePlatform{commonProto.DevicePlatform_ANDROID, commonProto.DevicePlatform_iOS},
+		Since:           time.Date(2023, time.January, 1, 0, 0, 0, 0, time.Local),
+		Until:           time.Date(2023, time.January, 31, 23, 59, 59, 999, time.Local),
+	}
+
+	// Fetch the first page of sessions with the specified configuration.
+	paginatedSessions, err := client.ListSessions(sessionListConfig)
+	for {
+		if err != nil {
+			fmt.Println("Error fetching session list")
+			fmt.Println(err)
+			break
+		}
+
+		// Iterate over the returned sessions, printing out a subset of information
+		for _, session := range paginatedSessions.Sessions {
+			fmt.Printf("SessionId: %s, %s - %s\n", session.SessionId, session.Metadata.Platform.String(), session.CreatedAt.AsTime())
+		}
+
+		// After iterating across the first page of sessions, check to see if there are more available for this
+		// criteria, and if so, fetch the next page of sessions.
+		if paginatedSessions.HasMoreSessions() {
+			paginatedSessions, err = paginatedSessions.NextPage()
+		} else {
+			break
+		}
+	}
+}
+
+func Example_describeSession() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	// Fetch the session information for the specified sessionID
+	session, err := client.DescribeSession("sessionID", false)
+	if err != nil {
+		fmt.Println("Error fetching session")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(session)
+}
+
+func Example_listSessionFeatures() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	// Fetch the Features for the specified session
+	featuresList, err := client.ListSessionFeatures("some session id", nil)
+	if err != nil {
+		fmt.Println("Error fetching session features")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(featuresList)
+}
+
+func Example_listSessionSignals() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	// Fetch the Signals for the specified session
+	signalsList, err := client.ListSessionSignals("some session id", nil)
+	if err != nil {
+		fmt.Println("Error fetching session signals")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(signalsList)
+}
+
+func Example_readSession() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	// Read the sealed bundles for the specified session
+	sealedBundles, err := client.ReadSession("some session id", nil)
+	if err != nil {
+		fmt.Println("Error fetching sealed bundles for session")
+		fmt.Println(err)
+	}
+
+	fmt.Println(sealedBundles)
+}
+
+func Example_updateSessionLabels() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	sessionId := "some session id"
+
+	// Fetch the session information for the specified sessionID
+	session, err := client.DescribeSession(sessionId, false)
+	if err != nil {
+		fmt.Println("Error fetching session")
+		fmt.Println(err)
+		return
+	}
+
+	// Examine the current labels
+	if len(session.Labels) > 0 {
+		fmt.Println(session.Labels)
+	}
+
+	// UpdateSessionLabels() replaces the current labels with the provided set of labels
+	newLabels := []string{"data_validation_success", "pointer_feature_generator_validation"}
+	err = client.UpdateSessionLabels(sessionId, newLabels)
+	if err != nil {
+		fmt.Println("Error updating session labels")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("Labels updated successfully")
+}
+
+func Example_whoAmI() {
+	// Create an SDKConfig with your secret token
+	sdkConfig := config.SDKConfig{
+		SecretToken: "<YOUR SECRET_TOKEN>",
+	}
+
+	// Create a Moonsense Client with the SDKConfig
+	client := moonsense.NewClient(sdkConfig)
+
+	response, err := client.WhoAmI()
+	if err != nil {
+		fmt.Println("Error fetching token information")
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(response)
+}

--- a/moonsense/models/paginated_session_list.go
+++ b/moonsense/models/paginated_session_list.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (
@@ -8,7 +22,10 @@ import (
 	dataPlaneSDKProto "github.com/moonsense/go-sdk/moonsense/models/pb/v2/data-plane-sdk"
 )
 
+// A PaginatedSessionList provides a wrapper around the list sessions response which allows for
+// paginated loading of the sessions.
 type PaginatedSessionList struct {
+	// The sessions contained on this page
 	Sessions []*dataPlaneSDKProto.Session
 
 	sessionListResponse *dataPlaneProto.SessionListResponse
@@ -16,6 +33,7 @@ type PaginatedSessionList struct {
 	dataPlaneClient     *api.DataPlaneClient
 }
 
+// Creates a new PaginatedSessionList.
 func NewPaginatedSessionList(sessionListResponse *dataPlaneProto.SessionListResponse,
 	listSessionConfig config.ListSessionConfig,
 	dataPlaneClient *api.DataPlaneClient) PaginatedSessionList {
@@ -28,6 +46,7 @@ func NewPaginatedSessionList(sessionListResponse *dataPlaneProto.SessionListResp
 	}
 }
 
+// Returns true when there are more sessions to be fetched, otherwise false.
 func (ps *PaginatedSessionList) HasMoreSessions() bool {
 	if ps.sessionListResponse == nil ||
 		ps.sessionListResponse.Pagination == nil {
@@ -37,6 +56,7 @@ func (ps *PaginatedSessionList) HasMoreSessions() bool {
 	return ps.sessionListResponse.Pagination.NextPage != 0
 }
 
+// Fetches the next page of sessions.
 func (ps *PaginatedSessionList) NextPage() (*PaginatedSessionList, *api.ApiErrorResponse) {
 	if !ps.HasMoreSessions() {
 		empty := PaginatedSessionList{}

--- a/moonsense/sdk.go
+++ b/moonsense/sdk.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Moonsense, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package moonsense
 
 import (
@@ -25,6 +39,7 @@ type clientImpl struct {
 	dataPlaneClient    *api.DataPlaneClient
 }
 
+// The Client interface defines the interface for interacting with the Moonsense Cloud.
 type Client interface {
 	// ListRegions retrieves the list of Data Plane regions in the Moonsense Cloud.
 	//
@@ -60,13 +75,16 @@ type Client interface {
 	WhoAmI() (*commonProto.TokenSelfResponse, *api.ApiErrorResponse)
 }
 
+// NewClient returns a new Moonsense Client with the provided SDKConfig.
+// If SDKConfig.SecretToken is not provided, the environment will be checked for the "MOONSENSE_SECRET_TOKEN" variable and will
+// use that as the secret token. If neither are provided, the SDK will panic().
 func NewClient(c config.SDKConfig) Client {
 	if c.SecretToken == "" {
 		secretToken := os.Getenv("MOONSENSE_SECRET_TOKEN")
 		if secretToken != "" {
 			c.SecretToken = secretToken
 		} else {
-			panic("A Secret Token must either be provided in Config.SecretToken or set as an environment variable `MOONSENSE_SECRET_TOKEN`")
+			panic("A Secret Token must either be provided in config.SecretToken or set as an environment variable `MOONSENSE_SECRET_TOKEN`")
 		}
 	}
 	if c.RootDomain == "" {


### PR DESCRIPTION
## Submission Checklist

 - [x] The source has been evaluated for API changes and semantic versioning changes are reflected properly
 - [ ] Documentation has been added for any public APIs
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request
 
## Description

This PR updates the `ApiClient` to speak proto over the wire instead of JSON.

This PR's base branch is from #1 . 

## Breakdown

- The `Content-Type` header is now set to `application/x-protobuf` if one is not set.
- We also now provide a default `Accept` header of `application/x-protobuf` if one is not set. It seemed that even if I only set the `Content-Type` of the request to `application/x-protobuf`, I was still getting `application/json` responses unless I forced it like this.
- When marshaling the requests and unmarshaling the responses we need to use `proto` and not `protojson`. Note: We still use `protojson` when reconstituting the sealed bundles as they are truly json.

## Validation

- Tested using the same `main.go` file I was using for the first PR and stepping through the code in the VSCode debugger to ensure that we were receiving bytes in the responses and that the labels update request was indeed marshaled into bytes and not json.

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]
