### PR TITLE
Apparently Go install is a bit different. Go get works as expected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Simple Go SDK for the Moonsense Cloud API.
 
 ## Installation
 
-Install the module using `go install`: 
+Install the module using `go get`: 
 
 ```shell
-go install github.com/moonsense/go-sdk
+go get github.com/moonsense/go-sdk
 ```
 
 ## Getting Started

--- a/moonsense/doc.go
+++ b/moonsense/doc.go
@@ -16,10 +16,10 @@
 //
 // # Getting started
 //
-// The best way to get started working with the SDK is to use `go install` to add the
+// The best way to get started working with the SDK is to use `go get` to add the
 // SDK to your Go dependencies explicitly.
 //
-//	go install github.com/moonsense/go-sdk
+//	go get github.com/moonsense/go-sdk
 //
 // Once you have installed the SDK, you will need an API secret key. Navigate to your App in the Moonsense Console and create a token.
 // You will need to save the generated secret key to a secure place.


### PR DESCRIPTION
## Submission Checklist

 - [x] The source has been evaluated for API changes and semantic versioning changes are reflected properly
 - [x] Documentation has been added for any public APIs
 - [x] A visual inspection of the `Files changed` tab was made prior to submitting the pull request
 
## Description

In the docs we need to reference `go get` instead of `go install` for the SDK.

## Breakdown

- Updated `README.md` and `doc.go` with the change from `go install` to `go get`.

## Validation

- Tested locally that I can pull the modules via `go get`.

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]
